### PR TITLE
Fixed unknown type name  that defined NO_PERSISTENCE   

### DIFF
--- a/src/MQTTAsync.h
+++ b/src/MQTTAsync.h
@@ -507,6 +507,8 @@ typedef int MQTTAsync_updateConnectOptions(void* context, MQTTAsync_connectData*
  */
 LIBMQTT_API int MQTTAsync_setUpdateConnectOptions(MQTTAsync handle, void* context, MQTTAsync_updateConnectOptions* co);
 
+#if !defined(NO_PERSISTENCE)
+
 /**
  * Sets the MQTTPersistence_beforeWrite() callback function for a client.
  * @param handle A valid client handle from a successful call to MQTTAsync_create().
@@ -530,6 +532,7 @@ LIBMQTT_API int MQTTAsync_setBeforePersistenceWrite(MQTTAsync handle, void* cont
  */
 LIBMQTT_API int MQTTAsync_setAfterPersistenceRead(MQTTAsync handle, void* context, MQTTPersistence_afterRead* co);
 
+#endif
 
 /** The data returned on completion of an unsuccessful API call in the response callback onFailure. */
 typedef struct


### PR DESCRIPTION

MQTTAsync.h(519): error: unknown type name 'MQTTPersistence_beforeWrite'
MQTTAsync.h(531): error: unknown type name 'MQTTPersistence_afterRead'
